### PR TITLE
optional raise error on failed request

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,21 @@ folder.clear_cache!
 folder.get('some_file.mp3') # will make API request again
 ```
 
+by default `OneDrive` returns hash with error when request failed
+(except file not found - in that case it returns instance of `OneDrive404`)
+
+but you can force library to raise exception instead
+
+```ruby
+Rb1drv.raise_on_failed_request = true
+begin
+  od.get('/invalid:folder2')
+rescue Rb1drv::Errors::ApiError => e
+  puts e.message # "Resource not found for the segment 'rootfolder2'."
+  puts e.code # "BadRequest"
+end
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/msg7086/rb1drv.

--- a/lib/rb1drv.rb
+++ b/lib/rb1drv.rb
@@ -49,8 +49,15 @@ module Rb1drv
       JSON.parse(response.body)
     end
   end
+
+  class << self
+    attr_accessor :raise_on_failed_request
+  end
+
+  self.raise_on_failed_request = false
 end
 
+require 'rb1drv/errors'
 require 'rb1drv/auth'
 require 'rb1drv/onedrive'
 require 'rb1drv/onedrive_item'

--- a/lib/rb1drv/errors.rb
+++ b/lib/rb1drv/errors.rb
@@ -1,0 +1,25 @@
+module Rb1drv
+  module Errors
+
+    class Error < StandardError
+    end
+
+    class ApiError < Error
+      attr_reader :api_hash
+
+      def initialize(api_hash)
+        @api_hash = api_hash
+        super(api_hash.dig('error', 'message'))
+      end
+
+      def code
+        api_hash.dig('error', 'code')
+      end
+
+      def inner_error
+        api_hash.dig('error', 'innererror') || {}
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
I've encountered many different cases when I got strange exception `<ArgumentError>: invalid date: nil` when using `rb1drv`

after some digging I've found that OneDrive API can give failed response in many different situations and on some cases.
For example root folder get may respond with not found, file upload can be not successful, etc.

This PR will help to get real reason why requests are fail