### PR TITLE
fix URI escaping

### DIFF
--- a/lib/rb1drv.rb
+++ b/lib/rb1drv.rb
@@ -32,7 +32,7 @@ module Rb1drv
       @logger.info(uri) if @logger
       auth_check
       query = {
-        path: File.join('v1.0/me/', URI.encode_www_form_component(uri).gsub('+', '%20')),
+        path: File.join('v1.0/me/', uri),
         headers: {
           'Authorization': "Bearer #{@access_token.token}"
         }
@@ -47,6 +47,10 @@ module Rb1drv
         response = @conn.get(query)
       end
       JSON.parse(response.body)
+    end
+
+    def url_path_encode(path)
+      URI.encode_www_form_component(path).gsub('+', '%20')
     end
   end
 

--- a/lib/rb1drv/onedrive.rb
+++ b/lib/rb1drv/onedrive.rb
@@ -14,7 +14,7 @@ module Rb1drv
     # @return [OneDriveDir,OneDriveFile] the drive item you asked
     def get(path)
       path = "/#{path}" unless path[0] == '/'
-      OneDriveItem.smart_new(self, request("drive/root:#{path}"))
+      OneDriveItem.smart_new(self, request("drive/root:/#{url_path_encode(path[1..-1])}"))
     end
 
     def skip_cache?

--- a/lib/rb1drv/onedrive_dir.rb
+++ b/lib/rb1drv/onedrive_dir.rb
@@ -41,7 +41,7 @@ module Rb1drv
     def get(path)
       path = "/#{path}" unless path[0] == '/'
       with_cache(:get, path) do
-        OneDriveItem.smart_new(@od, @od.request("#{api_path}:#{path}"))
+        OneDriveItem.smart_new(@od, @od.request("#{api_path}:/#{@od.url_path_encode(path[1..-1])}"))
       end
     end
 


### PR DESCRIPTION
My previous PR https://github.com/msg7086/rb1drv/pull/9 broke the gem.
Sorry.

Following OneDrive API documentation https://github.com/OneDrive/onedrive-api-docs/blob/live/docs/rest-api/concepts/addressing-driveitems.md#common-url-encoding-mistakes only `path` URI part should be escaped
